### PR TITLE
fix: when using roles only (no key and secret), remove also succeeds

### DIFF
--- a/src/SqsQueueReaderServiceProvider.php
+++ b/src/SqsQueueReaderServiceProvider.php
@@ -62,16 +62,23 @@ class SqsQueueReaderServiceProvider extends ServiceProvider
         $batchIds = array_column($data['data'], 'batchIds');
         $batchIds = array_chunk($batchIds, 10);
 
-        $client = new SqsClient([
+        $config = Config::get('queue.connections.sqs-json');
+
+        $sqsClientConfig = [
             //'profile' => 'default',
             'region' => Config::get('queue.connections.sqs-json.region'),
             'version' => '2012-11-05',
-            'credentials' => Arr::only(Config::get('queue.connections.sqs-json'), ['key', 'secret']),
             'http' => [
                 'timeout' => 30,
                 'connect_timeout' => 30,
             ],
-        ]);
+        ];
+
+        if ($config['key'] && $config['secret']) {
+            $sqsClientConfig['credentials'] = Arr::only($config, ['key', 'secret']);
+        }
+
+        $client = new SqsClient($sqsClientConfig);
 
         foreach ($batchIds as $batch) {
             //Deletes up to ten messages from the specified queue.


### PR DESCRIPTION
We are using your lovely package in an environment, where no key and secret are used. Role based access is used. Reading messages seems to work fine, but the removal not yet. 

I changed the code similar to the Connector class.